### PR TITLE
Opcion de "Seleccione una localidad" repetida

### DIFF
--- a/view/frontend/web/js/view/cart/shipping-rates.js
+++ b/view/frontend/web/js/view/cart/shipping-rates.js
@@ -125,9 +125,9 @@ define(
                         success : function (response)
                         {
                             $('#s_method_sucursal').attr('checked',false);
+                            andreaniSucursalLocalidad.append('<option>Seleccione una localidad</option>');
                             for(var i = 0; i < response.length; i++)
                             {
-                                andreaniSucursalLocalidad.append('<option>Seleccione una localidad</option>');
                                 andreaniSucursalLocalidad.append('<option value="'+response[i]["codigo_postal"]+'">'+response[i]["localidad"]+'</option>')
                             }
                             andreaniSucursalLocalidad.show();


### PR DESCRIPTION
Se mueve la linea donde agrega la opcion que indica la "seleccion de una localidad" fuera del bucle de control para evitar que se vea duplicada